### PR TITLE
fix meter plus

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,6 +107,8 @@ func run() error {
 
 		switch status.Type {
 		case switchbot.Meter:
+			fallthrough
+		case switchbot.MeterPlus:
 			meterHumidity := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Namespace: "switchbot",
 				Subsystem: "meter",

--- a/main.go
+++ b/main.go
@@ -106,9 +106,7 @@ func run() error {
 		}
 
 		switch status.Type {
-		case switchbot.Meter:
-			fallthrough
-		case switchbot.MeterPlus:
+		case switchbot.Meter, switchbot.MeterPlus:
 			meterHumidity := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Namespace: "switchbot",
 				Subsystem: "meter",


### PR DESCRIPTION
温湿度計プラスの温湿度が取得できていなかった問題に対応しました。

v1.1のドキュメント https://github.com/OpenWonderLabs/SwitchBotAPI#meter-plus-1 には typeには MeterPlus も `Meter` と返すと書いてありますが、なぜか値が取得できず様子を見たところ、しっかりと `MeterPlus` と入っていました。

v1.0時代からこうだったのかは切り分け調査していないので、 #2 のPullRequestを先にマージして v1.1 に追従してからこちらを見てもらえれば助かります。