### PR TITLE
Add plugElectricCurrent metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -147,10 +147,17 @@ func run() error {
 				Name:      "voltage",
 			}, []string{"device_id"})
 
+			plugElectricCurrent := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: "switchbot",
+				Subsystem: "plug",
+				Name:      "electricCurrent",
+			}, []string{"device_id"})
+
 			registry.MustRegister(deviceLabels)
-			registry.MustRegister(plugWeight, plugVoltage)
+			registry.MustRegister(plugWeight, plugVoltage, plugElectricCurrent)
 			plugWeight.WithLabelValues(status.ID).Set(status.Weight)
 			plugVoltage.WithLabelValues(status.ID).Set(status.Voltage)
+			plugElectricCurrent.WithLabelValues(status.ID).Set(status.ElectricCurrent)
 		}
 
 		promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP(w, r)


### PR DESCRIPTION
## Summary
This pull request adds the `switchbot_plug_electricCurrent` metric, which exposes the electric current of the SwitchBot API's plug. By combining this metric with `switchbot_plug_voltage`, users can more flexibly calculate power consumption.

## Changes
- Added the `switchbot_plug_electricCurrent` metric to expose the plug's electric current from the SwitchBot API
