### PR TITLE
Add support linux/arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,5 +54,6 @@ jobs:
       - name: push to docker hub
         uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Docker imageのビルドプラットフォームにlinux/arm64を追加しました。
(Raspberry Pi 5 で動かしたかったため)

不要でしたらクローズしてください。

---

ビルドとアップロードの成功、確認済みです。
- https://github.com/watahari/switchbot-exporter/actions/runs/13091012227/job/36527626932
- https://hub.docker.com/repository/docker/watahari/switchbot-exporter/tags

手元の Raspberry Pi 5 で動作しました。
(デバイスIDなどは伏せています)
```
$ uname -a
Linux XXXXXXX 6.6.62+rpt-rpi-2712 #1 SMP PREEMPT Debian 1:6.6.62-1+rpt1 (2024-11-25) aarch64 GNU/Linux
$ cat docker-compose.yaml | head -35 | tail -10
  switchbot-exporter:
    # image: nasa9084/switchbot-exporter
    image: watahari/switchbot-exporter
    container_name: switchbot-exporter
    ports:
      - 9101:8080
    restart: always
    environment:
      - SWITCHBOT_OPENTOKEN
      - SWITCHBOT_SECRETKEY
```
```
$ curl 'http://localhost:9101/metrics?target=XXXXXXX'
# HELP switchbot_device
# TYPE switchbot_device gauge
switchbot_device{device_id="XXXXXXX",device_name="エアコン"} 0
switchbot_device{device_id="XXXXXXX",device_name="テレビ"} 0
switchbot_device{device_id="XXXXXXX",device_name="RMT-B015J"} 0
switchbot_device{device_id="XXXXXXX",device_name="RM-AAU080"} 0
switchbot_device{device_id="XXXXXXX",device_name="Switchbot Hub 2"} 0
switchbot_device{device_id="XXXXXXX",device_name="カーテン"} 0
switchbot_device{device_id="XXXXXXX",device_name="Switchbot Contact Sensor"} 0
switchbot_device{device_id="XXXXXXX",device_name="防水温湿度計"} 0
# HELP switchbot_meter_humidity
# TYPE switchbot_meter_humidity gauge
switchbot_meter_humidity{device_id="XXXXXXX"} 37
# HELP switchbot_meter_temperature
# TYPE switchbot_meter_temperature gauge
switchbot_meter_temperature{device_id="XXXXXXX"} 21
```